### PR TITLE
Remove liked video in youtube

### DIFF
--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -11,10 +11,9 @@ A Script used to remove bulk like videos in Youtube at Once </br>
 # How to run in Local
 
 Open liked videos tab of youtube in browser and copy and paste the code from script.js to your console tab which is opened by `Ctrl+Shift+I` for windows and hit enter.
-</br>
+
 
 It will only remove 100 liked videos at once because browser can't handle long process and may crash
 
-</br>
 
-After 100 Videos will be removed, recopy and paste the code to console tab and to remove more videos😉
+After 100 Videos will be removed, recopy and paste the code to console tab to remove more videos😉

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -1,0 +1,20 @@
+# Description
+
+A Script used to remove bulk like videos in Youtube at Once </br>
+
+# Tech Stack
+
+[x] JavaScript
+
+# Demonstration
+
+# How to run in Local
+
+Open liked videos tab of youtube in browser and copy and paste the code from script.js to your console tab which is opened by `Ctrl+Shift+I` for windows and hit enter.
+</br>
+
+It will only remove 100 liked videos at once because browser can't handle long process and may crash
+
+</br>
+
+After 100 Videos will be removed, recopy and paste the code to console tab and to remove more videos😉

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -8,6 +8,9 @@ A Script used to remove bulk like videos in Youtube at Once </br>
 
 # Demonstration
 
+https://user-images.githubusercontent.com/71494616/156602176-0c0515cc-71fd-44f9-bb84-9d0250ae1ba1.mp4
+
+
 # How to run in Local
 
 Open liked videos tab of youtube in browser and copy and paste the code from script.js to your console tab which is opened by `Ctrl+Shift+I` for windows and hit enter.
@@ -17,3 +20,6 @@ It will only remove 100 liked videos at once because browser can't handle long p
 
 
 After 100 Videos will be removed, recopy and paste the code to console tab to remove more videos😉
+
+
+

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -10,6 +10,10 @@ A Script used to remove bulk like videos in Youtube at Once </br>
 
 https://user-images.githubusercontent.com/71494616/156602176-0c0515cc-71fd-44f9-bb84-9d0250ae1ba1.mp4
 
+#Concepts Used
+- Promise
+- await
+- function
 
 # How to run in Local
 

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -10,7 +10,7 @@ A Script used to remove bulk like videos in Youtube at Once </br>
 
 https://user-images.githubusercontent.com/71494616/156602176-0c0515cc-71fd-44f9-bb84-9d0250ae1ba1.mp4
 
-#Concepts Used
+# Concepts Used
 - Promise
 - await
 - function

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/README.md
@@ -4,7 +4,7 @@ A Script used to remove bulk like videos in Youtube at Once </br>
 
 # Tech Stack
 
-[x] JavaScript
+- [x] JavaScript
 
 # Demonstration
 

--- a/Web Development/Script_to_remove_liked_videos_in_youtube/script.js
+++ b/Web Development/Script_to_remove_liked_videos_in_youtube/script.js
@@ -1,0 +1,19 @@
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function deleteLikedVideos() {
+    'use strict';
+    var items = document.querySelectorAll('ytd-menu-renderer > yt-icon-button.dropdown-trigger > button[aria-label]');
+    var out;
+    for (var i = 0; i < items.length; i++) {
+        items[i].click();
+        out = setTimeout(function () {
+            if (document.querySelector('tp-yt-paper-listbox.style-scope.ytd-menu-popup-renderer').lastElementChild) {
+                document.querySelector('tp-yt-paper-listbox.style-scope.ytd-menu-popup-renderer').lastElementChild.click();
+            }
+        }, 100);
+        await sleep(500); // sleep cause browser can not handle the process 
+        clearTimeout(out);
+    }
+}
+deleteLikedVideos(); 


### PR DESCRIPTION
Pull Request for Issue No. #39

# Description

A Script used to remove bulk like videos in Youtube at Once 

# Tech Stack

- [x] JavaScript

# Demonstration

https://user-images.githubusercontent.com/71494616/156602176-0c0515cc-71fd-44f9-bb84-9d0250ae1ba1.mp4

# How to run in Local

Open liked videos tab of youtube in browser and copy and paste the code from script.js to your console tab which is opened by `Ctrl+Shift+I` for windows and hit enter.


It will only remove 100 liked videos at once because browser can't handle long process and may crash


After 100 Videos will be removed, recopy and paste the code to console tab to remove more videos😉
